### PR TITLE
Import test-utils directly from react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,7 @@
   "dependencies": {
     "@types/react": "15.0.22",
     "@types/react-dom": "15.5.0",
-    "@types/react-addons-test-utils": "0.14.18",
     "react": "15.5.4",
-    "react-addons-test-utils": "15.5.1",
     "react-dom": "15.5.4",
     "test-drive": "0.0.87"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {Simulate, SyntheticEventData} from "react-addons-test-utils";
+import {Simulate, SyntheticEventData} from 'react-dom/test-utils';
 export * from 'test-drive';
 export * from './client-renderer';
 
@@ -42,6 +42,4 @@ export interface CustomSimulate {
 }
 
 // We're changing only the typing of Simulate: allows null, doesn't expect React comp
-const ReactSimulate = Simulate as CustomSimulate;
-
-export { ReactSimulate as simulate };
+export const simulate = Simulate as CustomSimulate;


### PR DESCRIPTION
This was changed in React 15.5, for forward compatability with React 16's package structure.